### PR TITLE
Release Candidate 2026-07-09 21:07:55 +0900

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - release
 
@@ -26,8 +25,6 @@ concurrency:
 jobs:
   build:
     name: Build VitePress
-    # 'merged == true' to prevent from being triggered when PR is closed
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -54,7 +51,6 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event.pull_request.merged == true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -67,7 +63,6 @@ jobs:
 
   publish-release-note:
     name: Publish release note
-    if: github.event.pull_request.merged == true
     needs: deploy
     permissions:
       contents: write


### PR DESCRIPTION
## 1. Target
- [ ] #77 @sn0wm1ku

Promote `main` → `release` to publish the Coding Style Guide and activate the
fixed GitHub Pages deploy.

Contents (already reviewed/merged on `main`):
- Coding Style Guide (TypeScript, Go, Python, HTML & CSS) + shared config
  templates — #73
- Pages deploy fix: Release workflow now triggers on `push` to `release` so
  `deploy-pages` runs in an allowed environment context — #77 / #76

## 2. Specification / Test Plan

Merging this PR is a `push` to `release`. The pushed commit carries the fixed
`release.yml` (`on: push: branches:[release]`), so the Release workflow triggers,
builds VitePress, and deploys to GitHub Pages from the `release` context — now an
allowed deployment branch for the `github-pages` environment.

**Verify after merge:**
- The **Release** workflow run succeeds (build + deploy, no environment rejection).
- handbook.osbrjp.com serves the Style Guide (`/style-guide`, currently 404).

## 3. Notes for Shipping

First successful run of the release→Pages pipeline. If deploy still reports an
environment rejection, confirm `release` is in the `github-pages` environment's
allowed deployment branches (it was added in settings).