### PR TITLE
Pass label/branch-name values to shell via env, not template interpolation

### DIFF
--- a/.github/workflows/start-pull-request.yml
+++ b/.github/workflows/start-pull-request.yml
@@ -51,7 +51,7 @@ jobs:
       # Terminate if the issue has "idea" or "epic" label
       - name: Check issue type
         run: |
-          if echo "${{ env.LABELS }}" | grep -q "idea\|epic"; then
+          if echo "$LABELS" | grep -q "idea\|epic"; then
             echo "Issue type is either 'idea' or 'epic'. Exiting..."
             exit 1
           else
@@ -103,13 +103,13 @@ jobs:
           )
           git config user.name  "GitHub Actions"
           git config user.email "action@github.com"
-          git checkout -b "${{ env.NEW_BRANCH_NAME }}"
-          git commit --allow-empty -m "Initial commit for the issue #${{ github.event.issue.number }}"
-          git push origin "${{ env.NEW_BRANCH_NAME }}"
+          git checkout -b "$NEW_BRANCH_NAME"
+          git commit --allow-empty -m "Initial commit for the issue #$ISSUE_NUM"
+          git push origin "$NEW_BRANCH_NAME"
           gh pr create \
-            --head "${{ env.NEW_BRANCH_NAME }}" \
+            --head "$NEW_BRANCH_NAME" \
             --base "${{ github.event.repository.default_branch }}" \
             --title "$ISSUE_TITLE" \
-            --label "${{ env.LABELS }}" \
-            --assignee "${{ env.ASSIGNEES }}" \
+            --label "$LABELS" \
+            --assignee "$ASSIGNEES" \
             --body "$body"


### PR DESCRIPTION
Fixes #95.

`start-pull-request.yml` interpolated `${{ env.LABELS }}`, `${{ env.ASSIGNEES }}`, `${{ env.NEW_BRANCH_NAME }}` and `${{ github.event.issue.number }}` directly into `run:` script text. GitHub Actions substitutes `${{ }}` as text before the shell runs, so a value containing `$()` or backticks would execute on the runner — in a job holding `contents/issues/pull-requests: write` + `id-token: write`.

Not currently exploitable (every label/branch-name producer today is a hardcoded literal or numeric — see the issue for the scan panel's reasoning), but the safety was external to this file rather than built into it.

## Change
Every `run:` step now references the already-exported `$GITHUB_ENV` shell variables directly, matching the pattern already used elsewhere in the file (`:47-49`, `:66-68`). No `${{ env.* }}` interpolation remains in any `run:` step.

`${{ github.event.repository.default_branch }}` on `--base` is left as template interpolation — that's repo config, not user-influenceable data, so it's outside the injection class this issue describes.

## Testing
Workflow-only change, no app code touched — `app/` doesn't exist on `main` yet (POC is still on the unmerged `i68-handbook-poc` branch), so the `pnpm test`/`pnpm build` gates don't apply here.