### PR TITLE
Worker side of the CloudFront origin lock; fix the cache policy name blocking the plan

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,8 +1,8 @@
 name: Deploy Worker
 # Deploys the handbook Worker whenever app code or content lands on the
 # deployed branch — this is what makes an approved "Submit for approval" merge
-# actually appear on the site. During the POC that branch is i68-handbook-poc;
-# after the POC merges, pushes to main take over (same worker, same workflow).
+# actually appear on the site. That branch is main (the POC branch merged in
+# PR #72 on 2026-08-27 and its targeting was retired with it).
 #
 # INERT UNTIL CONFIGURED: requires the CLOUDFLARE_API_TOKEN repo secret
 # (repo admin: Settings → Secrets and variables → Actions; token needs
@@ -14,7 +14,6 @@ name: Deploy Worker
 on:
   push:
     branches:
-      - i68-handbook-poc
       - main
     paths:
       - "app/**"

--- a/POC.md
+++ b/POC.md
@@ -250,9 +250,8 @@ Deploy-mechanics facts, learned the hard way — read before deploying:
   Storage: Edit** (the adapter provisions a SESSION KV namespace).
 
 Worker configuration (dashboard → Settings → Variables and Secrets):
-vars `GITHUB_OAUTH_CLIENT_ID`, `OAUTH_ORIGIN` (dashboard-managed), and
-`GITHUB_BRANCH` (pinned in `wrangler.toml` `[vars]` — losing it silently
-retargets editor PRs to `main`); Secrets `COOKIE_ENCRYPTION_KEY`,
+vars `GITHUB_OAUTH_CLIENT_ID`, `OAUTH_ORIGIN` (dashboard-managed);
+Secrets `COOKIE_ENCRYPTION_KEY`,
 `GITHUB_OAUTH_CLIENT_SECRET` (+ `GITHUB_TOKEN`, see below).
 
 **Current auth state (since 2026-07-09): the org GitHub App is live** —
@@ -267,15 +266,17 @@ PAT + demo OAuth app from the pre-App workaround. (For the record, the classic
 fallback's minimal PAT scope was live-verified as `public_repo` + `read:org` —
 lesser scopes fail the collaborator API.)
 
-**POC-period editing on staging:** `GITHUB_BRANCH=i68-handbook-poc` (pinned
-in `wrangler.toml` `[vars]`), so the draft→submit→approve→merge loop demos
-against the POC branch — merged pages land on the branch staging is actually
-built from. The targeting is **self-retiring**: when the POC branch is deleted
-(its PR merged), everything automatically targets `main`; the only follow-up
-is a cleanup task (delete the var for tidiness, prune any demo pages/branches).
+**POC-period branch targeting — RETIRED 2026-08-27.** While the POC ran,
+`GITHUB_BRANCH=i68-handbook-poc` aimed editor PRs at the branch staging was
+built from. PR #72 merged that branch and the pin is gone from
+`wrangler.toml` and from the Worker's dashboard vars, so content work targets
+`main` via `resolveBase()`'s default. Note for anyone re-adding a pin:
+`keep_vars = true` means deleting the line here does NOT clear the var from
+the deployed Worker — it must also be deleted in the dashboard, or a stale
+value keeps overriding the default invisibly.
 
 **Deploy-on-push CI:** `.github/workflows/deploy-worker.yml` deploys the
-Worker on pushes to the deployed branch (POC branch now, `main` post-merge) —
+Worker on pushes to the deployed branch (`main`) —
 this is what makes an approved submission actually appear on the site. It is
 INERT until a repo admin adds the `CLOUDFLARE_API_TOKEN` repo secret (Workers
 Scripts:Edit + Workers KV Storage:Edit); until then it skips with a notice and
@@ -437,10 +438,19 @@ documented there under `application-security.md` §3-16 — was considered and
   hostname. It is dashboard-managed and survives deploys via `keep_vars = true`
   (see `app/wrangler.toml`), so this is a dashboard change, not a commit.
 
-Note the `*.workers.dev` hostname stays publicly reachable alongside
-CloudFront. That is acceptable — the Worker enforces auth itself — but two
-hostnames then serve the same gated content, and the origin check should
-reject the one we don't intend.
+**The second hostname, and the origin lock (built 2026-08-27).** The
+`*.workers.dev` name stays publicly reachable alongside CloudFront — Cloudflare
+gives no way to switch it off — so two hostnames serve the same gated content.
+The Worker enforces auth on both, but the direct one skips everything the
+distribution adds: the WAF, HSTS, and the `Origin` rewrite the editor needs.
+
+`app/src/lib/auth/originLock.ts` closes it. CloudFront attaches
+`X-Origin-Verify` as an **origin custom header**, which it overwrites on every
+request, so a viewer cannot forge one; the Worker refuses anything that lacks
+the matching value. It is **engaged by setting `ORIGIN_VERIFY_SECRET`, not by
+deploying** — unset means off. That default is deliberate: the distribution has
+to be verified end-to-end *before* DNS moves, and that testing hits a Worker
+nothing fronts yet. Rollback is `wrangler secret delete`, not a redeploy.
 
 **Before the swap:** drop the `handbook` CNAME TTL in Route 53 from 3600 to
 60–300. It is free, has zero user impact, and it is what makes both the
@@ -524,7 +534,13 @@ be internal" as an open content question, not a solved one.
       - **The ACL still holds.** The corpus is currently all-`public`, so
         temporarily mark one page `internal` to test it: 404 anonymously,
         renders once signed in. Revert afterwards.
-   6. In Route 53 (TTL already lowered): point `handbook` at the distribution.
+   6. **Engage the origin lock** — only now, with the checks above green.
+      `wrangler secret put ORIGIN_VERIFY_SECRET` on the Worker, matching
+      Terraform's `origin_secret`. Re-run the editor save through the
+      distribution, then confirm `osbr-handbook.osbrjp.workers.dev` answers
+      **403 Direct access is not allowed**. Doing this before step 5 would 403
+      the very tests step 5 depends on.
+   7. In Route 53 (TTL already lowered): point `handbook` at the distribution.
 
    **Rollback** = restore `CNAME → osbrjp.github.io`. Keep Pages alive until
    step 8 precisely so rollback stays one step. Both sites stay up throughout —

--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -16,10 +16,18 @@ export default defineConfig({
   // pinned explicitly because it is load-bearing security that would otherwise
   // vanish silently on a default change, and because it constrains deployment:
   // the check compares against the URL THE WORKER RECEIVES, never
-  // `x-forwarded-host`, so any proxy in front (the planned CloudFront
-  // distribution) MUST forward the original Host or every editor POST 403s.
-  // See POC.md "Migration & production cutover". This layers over — and does
-  // not replace — the app's own double-submit token in src/lib/csrf.ts.
+  // `x-forwarded-host`.
+  //
+  // How that constraint is actually met — NOT by forwarding the viewer's Host,
+  // which an earlier revision of this comment claimed. Cloudflare's edge
+  // rejects any Host that is not the workers.dev name (measured 2026-08-21),
+  // so a proxy that forwarded it would 403 the entire site before the Worker
+  // ran. The CloudFront viewer-request function rewrites the `Origin` header
+  // instead (infra/functions/viewer-request.js): the one legitimate public
+  // origin becomes the workers.dev origin the Worker sees, while a cross-site
+  // POST keeps its own Origin, mismatches, and is still rejected. See POC.md
+  // "CHOSEN: CloudFront rewrites the Origin header". This layers over — and
+  // does not replace — the app's own double-submit token in src/lib/csrf.ts.
   //
   // NOT a fix for that *on this adapter*: `security.allowedDomains`. It exists
   // in Astro 7 and looks like the answer (it allowlists hosts and then trusts

--- a/app/src/env.d.ts
+++ b/app/src/env.d.ts
@@ -9,6 +9,12 @@ declare namespace Cloudflare {
     COOKIE_ENCRYPTION_KEY: string;
     DEV_LOGIN?: string;
     OAUTH_ORIGIN?: string;
+    // Shared secret CloudFront sends as X-Origin-Verify, so the Worker can
+    // refuse requests that bypassed the distribution. UNSET = lock off (the
+    // workers.dev host stays reachable) — see lib/auth/originLock.ts. Worker
+    // secret, never committed; the same value lives in Terraform's
+    // origin_secret.
+    ORIGIN_VERIFY_SECRET?: string;
     // GitHub App or classic OAuth App (login) — identity only, no scopes
     GITHUB_OAUTH_CLIENT_ID?: string;
     GITHUB_OAUTH_CLIENT_SECRET?: string;

--- a/app/src/layouts/Base.astro
+++ b/app/src/layouts/Base.astro
@@ -2,7 +2,6 @@
 import "../styles/global.css";
 import Icon from "../components/Icon.astro";
 import { isEditorRole, type Visitor } from "../lib/auth/visitor";
-import { environmentName, hostOf } from "../lib/env";
 import { SITE_TITLE } from "../lib/site";
 
 interface Props {
@@ -10,10 +9,6 @@ interface Props {
   visitor?: Visitor | null;
 }
 const { title, visitor = null } = Astro.props;
-// Environment ribbon above EVERYTHING (even the header) on non-production
-// hosts, so nobody mistakes local/staging for the live handbook. Production
-// renders nothing.
-const env = environmentName(hostOf(Astro.locals.publicOrigin));
 ---
 
 <!doctype html>
@@ -37,15 +32,6 @@ const env = environmentName(hostOf(Astro.locals.publicOrigin));
     </script>
   </head>
   <body>
-    {
-      env !== "production" && (
-        <div class={`env-ribbon env-ribbon-${env}`}>
-          {env === "local"
-            ? "LOCAL environment — this is a development copy, not the live handbook"
-            : "POC environment — a proof-of-concept demo, not the live handbook"}
-        </div>
-      )
-    }
     <header class="site-header">
       <a class="brand" href="/">
         <img class="brand-logo" src="/logo1.svg" alt="OSBR" width="32" height="32" />

--- a/app/src/lib/auth/originLock.ts
+++ b/app/src/lib/auth/originLock.ts
@@ -1,0 +1,56 @@
+// The Worker side of the "origin lock" (infra/README.md). Distinct from
+// origin.ts, which resolves the app's own public URL — this decides whether a
+// request is allowed to reach the app at all.
+//
+// The Worker answers on two hostnames: the CloudFront distribution that serves
+// the public handbook, and its own *.workers.dev name. Cloudflare does not let
+// us switch the latter off, and it serves the same gated content, so until the
+// Worker checks provenance the CDN is advisory: anyone who learns the
+// workers.dev name bypasses CloudFront and with it the WAF, the HSTS header,
+// and the Origin rewrite the editor depends on.
+//
+// CloudFront attaches X-Origin-Verify as an ORIGIN CUSTOM HEADER, which it
+// OVERWRITES on every request (infra/main.tf). A viewer therefore cannot forge
+// or smuggle one, so the right value is proof the request came through the
+// distribution.
+export const ORIGIN_VERIFY_HEADER = "x-origin-verify";
+
+/**
+ * May this request reach the app?
+ *
+ * ENGAGED BY SETTING THE SECRET, not by deploying this code. An unset secret
+ * means the lock is off, which is deliberate and load-bearing:
+ *
+ *   - it keeps the workers.dev host usable while CloudFront is still being
+ *     built and verified (the distribution has to be tested end-to-end BEFORE
+ *     DNS moves, and that testing happens against a Worker nothing fronts yet);
+ *   - it makes disengaging a one-step rollback — `wrangler secret delete
+ *     ORIGIN_VERIFY_SECRET` — instead of a redeploy, which matters because
+ *     getting this wrong takes the whole site down rather than degrading it.
+ *
+ * So the safe order is: apply CloudFront, verify through the distribution,
+ * THEN set this secret to the same value Terraform holds. Setting it first
+ * 403s every reader, including the ones arriving through it.
+ */
+export function edgeRequestAllowed(
+  presented: string | null | undefined,
+  secret: string | undefined,
+): boolean {
+  if (!secret) return true;
+  if (!presented) return false;
+  return constantTimeEqual(presented, secret);
+}
+
+// Compared without an early exit on the first differing byte. A remote timing
+// attack through two CDNs is far-fetched, but this costs microseconds and the
+// alternative is a `===` that every future reviewer has to re-reason about.
+// Length is allowed to short-circuit: the secret's length is not a secret.
+// Safe for the base64 values Terraform generates (all single UTF-16 units).
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/app/src/lib/content/store.github.ts
+++ b/app/src/lib/content/store.github.ts
@@ -129,14 +129,6 @@ export async function readPageAtRef(
 }
 
 /**
- * Which branch content work should target. Normally `main` — but during the
- * POC period staging sets GITHUB_BRANCH to the POC branch so editor
- * submissions demo against the code that's actually deployed. The rule is
- * self-retiring: use the configured branch WHILE IT EXISTS; once it's deleted
- * (which happens when its PR merges), everything automatically targets `main`
- * — no config change needed at merge time.
- */
-/**
  * Discard a DRAFT-ONLY page (never merged/published): delete its edit branch.
  * GitHub auto-closes any open PR whose head branch is deleted, so this is the
  * whole "discard" in one call. No review step — nothing was ever public.
@@ -159,6 +151,13 @@ export async function discardDraft(
   return true;
 }
 
+/**
+ * Which branch content work should target: `main` unless GITHUB_BRANCH aims it
+ * elsewhere (a POC/demo period pointing editor PRs at the branch that's
+ * actually deployed). Self-retiring by design — the configured branch is used
+ * WHILE IT EXISTS, so once it's deleted (i.e. its PR merged) targeting falls
+ * back to `main` with no config change needed at merge time.
+ */
 export async function resolveBase(
   config: GithubConfig,
   fetchImpl: typeof fetch = fetch,

--- a/app/src/lib/env.ts
+++ b/app/src/lib/env.ts
@@ -1,21 +1,9 @@
-// Which environment is this request being served from? ONE source of truth,
-// shared by the middleware (X-Robots-Tag: noindex off-prod) and the visible
-// environment ribbon (Base layout).
-//   local      — `astro dev` on a laptop
-//   poc        — a built Worker on any host that isn't the real domain
-//                (osbr-handbook.*.workers.dev, previews, ...). Named for what
-//                it IS during the evaluation period — a proof of concept, not
-//                the blessed staging of a production system. The real domain
-//                shows no ribbon at all, so the label retires with the POC.
-//   production — the one canonical host
+// The one canonical host. Every other host — workers.dev, previews, localhost
+// — is a copy, and the middleware serves those X-Robots-Tag: noindex so a
+// staging copy never reaches search results. That header is now the ONLY thing
+// distinguishing a copy from the real site: the on-page environment ribbon was
+// removed deliberately, so a reader cannot tell by looking.
 export const PROD_HOST = "handbook.osbrjp.com";
-
-export type EnvName = "local" | "poc" | "production";
-
-export function environmentName(host: string): EnvName {
-  if (import.meta.env.DEV) return "local";
-  return host === PROD_HOST ? "production" : "poc";
-}
 
 /**
  * Host of an origin URL, "" if unparseable.
@@ -24,8 +12,8 @@ export function environmentName(host: string): EnvName {
  * `Astro.url.host` or the request `Host` header. Behind the CloudFront reverse
  * proxy those carry the ORIGIN's hostname (the workers.dev name), never the
  * host the visitor typed, so a Host-based check reports the wrong environment:
- * the live handbook would render the "poc" ribbon and serve `X-Robots-Tag:
- * noindex` on every page, forever.
+ * the live handbook would serve `X-Robots-Tag: noindex` on every page, forever
+ * — invisibly keeping the real site out of search results.
  */
 export function hostOf(origin: string): string {
   try {

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -8,6 +8,7 @@ import {
 } from "./lib/auth/github";
 import { SESSION_COOKIE, sessionCookieOptions } from "./lib/auth/cookies";
 import { getOrigin } from "./lib/auth/origin";
+import { edgeRequestAllowed, ORIGIN_VERIFY_HEADER } from "./lib/auth/originLock";
 import { decryptSession, encryptSession, type GhTokenSet } from "./lib/auth/session";
 import type { Visitor } from "./lib/auth/visitor";
 
@@ -34,6 +35,22 @@ const TOKEN_HEADROOM_MS = 2 * 60_000;
 // minted and is RE-VERIFIED here once it's older than ROLE_TTL_MS — no
 // database, no directory, no allow-list in the codebase.
 export const onRequest = defineMiddleware(async (ctx, next) => {
+  // Provenance FIRST: a request that did not come through CloudFront gets
+  // nothing — not a session decrypt, not a GitHub round-trip. Off until the
+  // ORIGIN_VERIFY_SECRET is set; see lib/auth/originLock.ts for why that
+  // default is deliberate and what order to engage it in.
+  if (
+    !edgeRequestAllowed(ctx.request.headers.get(ORIGIN_VERIFY_HEADER), env.ORIGIN_VERIFY_SECRET)
+  ) {
+    // 403 over 404 on purpose: the corpus is public, so this hides nothing,
+    // and an operator staring at the wrong hostname needs to be able to TELL
+    // that from the editor's other 403s (POC.md leans on exactly that).
+    return new Response(`Direct access is not allowed; use https://${PROD_HOST}/.\n`, {
+      status: 403,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  }
+
   ctx.locals.visitor = null;
   // The origin visitors typed. Behind a reverse proxy (CloudFront) the request
   // Host is the ORIGIN's hostname, so ctx.request/Astro.url identify the wrong

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -1494,23 +1494,6 @@ details[open] > summary.review-pane-toggle::before {
   padding: 1rem 1.25rem;
 }
 
-/* Environment ribbon — sits above the header on local/staging (never prod). */
-.env-ribbon {
-  text-align: center;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  padding: 0.3rem 1rem;
-}
-.env-ribbon-local {
-  background: #4749c7;
-  color: #fff;
-}
-.env-ribbon-poc {
-  background: #b98900;
-  color: #fff;
-}
-
 /* Delete confirmation modal. */
 .confirm-dialog {
   /* the global `* { margin: 0 }` reset kills the UA's dialog centering

--- a/app/tests/env.test.mjs
+++ b/app/tests/env.test.mjs
@@ -6,11 +6,11 @@ const { hostOf, PROD_HOST } = await import("../src/lib/env.ts");
 // Regression guard for a bug that is INVISIBLE at runtime: behind the
 // CloudFront reverse proxy the request Host is the workers.dev origin name,
 // never the host the visitor typed. Anything keyed on the request Host
-// therefore decides "this is not production" on the real handbook — which
-// renders the "poc" ribbon and, worse, sets X-Robots-Tag: noindex on every
-// page, keeping the live site out of search results indefinitely. The site
-// looks perfect while it happens. Identity must come from OAUTH_ORIGIN
-// (locals.publicOrigin), which is why hostOf takes an ORIGIN, not a host.
+// therefore decides "this is not production" on the real handbook — setting
+// X-Robots-Tag: noindex on every page and keeping the live site out of search
+// results indefinitely. The site looks perfect while it happens. Identity must
+// come from OAUTH_ORIGIN (locals.publicOrigin), which is why hostOf takes an
+// ORIGIN, not a host.
 test("hostOf extracts the host from a public origin", () => {
   assert.equal(hostOf("https://handbook.osbrjp.com"), PROD_HOST);
   assert.equal(hostOf("https://handbook.osbrjp.com/"), PROD_HOST);
@@ -20,7 +20,7 @@ test("hostOf extracts the host from a public origin", () => {
 
 test("hostOf returns '' for junk rather than throwing (fails closed to noindex)", () => {
   // A throw here would 500 every response; "" simply never equals PROD_HOST,
-  // so the safe outcome (noindex + ribbon) is what a malformed value gets.
+  // so the safe outcome (noindex) is what a malformed value gets.
   assert.equal(hostOf(""), "");
   assert.equal(hostOf("not-a-url"), "");
   assert.equal(hostOf("handbook.osbrjp.com"), ""); // bare host is NOT an origin

--- a/app/tests/origin-lock.test.mjs
+++ b/app/tests/origin-lock.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const { edgeRequestAllowed, ORIGIN_VERIFY_HEADER } = await import("../src/lib/auth/originLock.ts");
+
+// Shaped like the real thing (base64 of 32 bytes) but NOT a live value —
+// the deployed secret exists only in Terraform and the Worker.
+const SECRET = "dGVzdC1vbmx5LW5vdC1hLXJlYWwtc2VjcmV0LXZhbHVlIQ==";
+
+test("lock is OFF while the secret is unset — the workers.dev host stays reachable", () => {
+  // The distribution has to be verified end-to-end before DNS moves, and that
+  // testing hits a Worker nothing fronts yet. Regressing this to fail-closed
+  // would make the Worker unreachable the moment it deploys.
+  assert.equal(edgeRequestAllowed(null, undefined), true);
+  assert.equal(edgeRequestAllowed(null, ""), true);
+  assert.equal(edgeRequestAllowed("anything", undefined), true);
+});
+
+test("lock ON: the matching value passes, everything else is refused", () => {
+  assert.equal(edgeRequestAllowed(SECRET, SECRET), true);
+  assert.equal(edgeRequestAllowed(null, SECRET), false); // straight to workers.dev
+  assert.equal(edgeRequestAllowed(undefined, SECRET), false);
+  assert.equal(edgeRequestAllowed("", SECRET), false);
+  assert.equal(edgeRequestAllowed("wrong", SECRET), false);
+});
+
+test("a near-miss is still refused (no prefix/length shortcuts)", () => {
+  assert.equal(edgeRequestAllowed(SECRET.slice(0, -1), SECRET), false); // truncated
+  assert.equal(edgeRequestAllowed(`${SECRET}x`, SECRET), false); // extended
+  assert.equal(edgeRequestAllowed(SECRET.toLowerCase(), SECRET), false); // case matters
+  assert.equal(edgeRequestAllowed(` ${SECRET}`, SECRET), false); // not trimmed
+});
+
+test("header name is lowercase — Headers.get is case-insensitive, but Workers normalizes", () => {
+  assert.equal(ORIGIN_VERIFY_HEADER, "x-origin-verify");
+  const req = new Request("https://example.test/", { headers: { "X-Origin-Verify": SECRET } });
+  assert.equal(req.headers.get(ORIGIN_VERIFY_HEADER), SECRET);
+  assert.equal(edgeRequestAllowed(req.headers.get(ORIGIN_VERIFY_HEADER), SECRET), true);
+});

--- a/app/wrangler.toml
+++ b/app/wrangler.toml
@@ -16,22 +16,24 @@ keep_vars = true
 
 # Non-secret vars. DEV_LOGIN is "0" here (prod-safe default); .dev.vars sets it
 # to "1" for local dev only. Secrets (COOKIE_ENCRYPTION_KEY, GITHUB_OAUTH_*,
-# GITHUB_TOKEN) live in .dev.vars locally and as Worker secrets in prod — never here.
+# GITHUB_TOKEN, ORIGIN_VERIFY_SECRET) live in .dev.vars locally and as Worker
+# secrets in prod — never here.
+#
+# ORIGIN_VERIFY_SECRET engages the origin lock (src/lib/auth/originLock.ts):
+# once set, only requests carrying CloudFront's X-Origin-Verify header are
+# served, so the workers.dev host stops answering. Set it AFTER the
+# distribution is verified, not before — and match infra's origin_secret.
 [vars]
 DEV_LOGIN = "0"
 GITHUB_REPO = "osbrjp/handbook"
-# Pinned in the repo (not dashboard-only) because losing it is SILENT and bad:
-# resolveBase() falls back to main, so POC-period editor submissions would
-# open PRs against the production source branch instead of the POC branch.
-# Identical in demo and end states; self-retiring — once the POC branch is
-# merged+deleted, resolveBase() falls back to main by design. Remove at cutover.
-GITHUB_BRANCH = "i68-handbook-poc"
+# No GITHUB_BRANCH: content work targets main (resolveBase()'s default). Set it
+# only to aim editor PRs at a different branch — e.g. a future POC/demo period.
 
 # NOTE: no [env.staging] here on purpose. The Cloudflare adapter flattens the
 # generated deploy config to the base environment, so named envs are inert —
 # `wrangler deploy --env staging` would deploy this same worker. The single
 # `osbr-handbook` worker IS staging until the production cutover (POC.md
-# "Deploy to staging" has the full story, incl. GITHUB_BRANCH POC targeting).
+# "Deploy to staging" has the full story).
 
 # SESSION KV namespace (Astro Sessions). The adapter emits this binding WITHOUT
 # an id, so every deploy would otherwise show a config diff and risk rebinding

--- a/infra/README.md
+++ b/infra/README.md
@@ -31,7 +31,7 @@ yet, so plan and apply are run by hand today — see **Still open** below.
 | ACM certificate (us-east-1) | CloudFront reads its certificate from us-east-1 only. |
 | Distribution | Custom origin, HTTPS-only to the Worker, TLS 1.2+. |
 | `Managed-AllViewerExceptHostHeader` | workers.dev routes by `Host`; the origin must receive its own domain, not the viewer's. |
-| `Managed-UseOriginCacheControlHeaders-QueryStrings` (default) | Keeps every cookie in the cache key, so an authenticated page cannot be served to another reader, and honours the `Cache-Control` the Worker sends. |
+| `UseOriginCacheControlHeaders-QueryStrings` (default) | Keeps every cookie in the cache key, so an authenticated page cannot be served to another reader, and honours the `Cache-Control` the Worker sends. |
 | `Managed-CachingOptimized` (`/_astro/*`) | Astro's build output is content-hashed and identical for everyone — cached once, not once per cookie. |
 | `Managed-CachingDisabled` (`/api/*`) | The auth surface is never cached. |
 | `handbook-hsts` response headers policy | The Worker sets the other security headers; HSTS is the gap. |
@@ -81,9 +81,13 @@ rewrite fixes the CSRF check, not the app's sense of its own identity — see
 
 ## Still open
 
-- **Worker side of the origin lock.** The Worker must check `X-Origin-Verify`
-  and refuse requests without it. That code lives in the Worker's repository,
-  not here, so until it lands the workers.dev URL is still reachable directly.
+- **Origin lock — code landed, not yet engaged.** The Worker checks
+  `X-Origin-Verify` (`app/src/lib/auth/originLock.ts`) and refuses anything
+  without it, but only once `ORIGIN_VERIFY_SECRET` is set on the Worker; unset
+  means off, so the workers.dev URL is still reachable today. Engage it AFTER
+  this distribution is applied and verified — setting it first 403s every
+  reader — with `wrangler secret put ORIGIN_VERIFY_SECRET` matching the
+  `origin_secret` here. Rollback is `wrangler secret delete`, no redeploy.
 - **CI with OIDC.** #98 asks for plan and apply to run from CI on short-lived
   OIDC credentials. That needs an IAM role and trust policy that do not exist in
   the account yet, so the workflow is not written — a workflow without the role

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -9,8 +9,13 @@ data "aws_route53_zone" "root" {
 
 # CloudFront's managed policies cover every case here, so the only policy we
 # own is the one that adds the header the Worker does not send (see below).
+#
+# NOTE the missing "Managed-" prefix: the two UseOriginCacheControlHeaders
+# policies are the only managed cache policies AWS does not prefix. Adding it
+# for consistency fails the lookup and blocks the whole distribution from
+# planning. Verified against list-cache-policies --type managed, 2026-08-27.
 data "aws_cloudfront_cache_policy" "use_origin_cache_control" {
-  name = "Managed-UseOriginCacheControlHeaders-QueryStrings"
+  name = "UseOriginCacheControlHeaders-QueryStrings"
 }
 
 data "aws_cloudfront_cache_policy" "caching_optimized" {


### PR DESCRIPTION
## What

**Worker checks `X-Origin-Verify`** (`app/src/lib/auth/originLock.ts`, wired first in `middleware.ts`) and refuses requests that bypassed the CloudFront distribution. Closes the first item under "Still open" in `infra/README.md`: the `*.workers.dev` host served the same gated content while skipping the WAF, HSTS, and the `Origin` rewrite the editor depends on.

**Engaged by setting `ORIGIN_VERIFY_SECRET`, not by deploying — unset means off.** Deliberate: the distribution has to be verified end-to-end *before* DNS moves, against a Worker nothing fronts yet; and rollback should be `wrangler secret delete`, not a redeploy. POC.md gains cutover step 6 ("engage the origin lock") between the distribution checks and the DNS swap.

**`infra/main.tf`: unblocks `terraform plan`.** `UseOriginCacheControlHeaders-QueryStrings` is one of the two managed cache policies AWS ships *without* the `Managed-` prefix, so the data source couldn't resolve and the distribution never planned. Verified against `list-cache-policies`; the policy really does key the cache on every cookie, as the README claims.

**`astro.config.mjs`** comment corrected — it still said a proxy MUST forward the viewer's `Host`, which was measured to be impossible on 2026-08-21.

Also folds in: post-#72 retirement of POC-branch targeting (`GITHUB_BRANCH` pin, deploy-worker branch list), and the environment-ribbon removal.

## Verified

Ran in workerd (`wrangler dev`) both ways:

| `ORIGIN_VERIFY_SECRET` | Request | Result |
|---|---|---|
| set | no header (direct to workers.dev) | **403** `Direct access is not allowed…` |
| set | wrong value | **403** |
| set | matching value (via CloudFront) | **200** |
| set | `/api/auth/login`, no header | **403** — auth surface covered |
| **unset** | no header | **200** — staging unaffected |

Gates: `pnpm check` 0 errors · `pnpm test` 102/102 · `pnpm guard` OK · `pnpm build` clean · `infra` function tests 18/18. `terraform plan` now resolves all 6 resources.

## Operator steps (not in this PR)

1. `cd infra && sh scripts/deploy.sh` — applies the saved plan (cert + distribution; `enable_dns_cutover=false`, so `handbook.osbrjp.com` keeps serving GitHub Pages).
2. Verify through the distribution hostname per POC.md step 5 — a real editor save/approve/reject is the check that matters.
3. `wrangler secret put ORIGIN_VERIFY_SECRET` matching Terraform's `origin_secret`. Confirm workers.dev now 403s.
4. Lower the Route 53 TTL, then flip `enable_dns_cutover`.

No secrets in this diff — the only secret-shaped string is a synthetic test fixture that decodes to `test-only-not-a-real-secret-value!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)